### PR TITLE
Updating the version number for WP 6.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Change log
 
+## [[2.0.1]](https://github.com/lightspeeddevelopment/lsx-mega-menus/releases/tag/2.0.1) - 2023-08-09
+
+### Security
+- General testing to ensure compatibility with latest WordPress version (6.3).
+
 ## [[2.0.0]](https://github.com/lightspeeddevelopment/lsx-mega-menus/releases/tag/2.0.0) - 2023-06-05
 - The LSX Mega Menu has been updated to work with the site editor and the core navigation block.
 

--- a/lsx-mega-menus.php
+++ b/lsx-mega-menus.php
@@ -3,7 +3,7 @@
  * Plugin Name: LSX Mega Menus
  * Plugin URI:  https://www.lsdev.biz/product/lsx-mega-menus/
  * Description: Build mega menus using blocks, comes with existing template parts to help users get started within the site editor.
- * Version:     2.0.0
+ * Version:     2.0.1
  * Author:      LightSpeed
  * Author URI:  https://www.lsdev.biz/
  * License:     GPL3
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 define('LSX_MEGAMENU_PATH', plugin_dir_path(__FILE__));
 define('LSX_MEGAMENU_CORE', __FILE__);
 define('LSX_MEGAMENU_URL', plugin_dir_url(__FILE__));
-define('LSX_MEGAMENU_VER', '2.0.0');
+define('LSX_MEGAMENU_VER', '2.0.1');
 
 require_once LSX_MEGAMENU_PATH . 'includes/class-core.php';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsx-mega-menus",
-  "version": "1.2.7",
+  "version": "2.0.1",
   "description": "Mega Menus for LSX",
   "main": "gulpfile.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: feedmymedia, lightspeedwp, eleshar, krugazul, jacquesvdh, ignusver
 Donate link: https://lsdev.biz/lsx/donate/
 Tags: lsx, lsx-design, mega menu, nav menu, navigation, site editor
 Requires at least: 6.1
-Tested up to: 6.2.2
-Requires PHP: 8.0
-Stable tag: 2.0.0
+Tested up to: 6.3
+Requires PHP: 7.4
+Stable tag: 2.0.1
 License: GPLv3
 Licence URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 


### PR DESCRIPTION
### Description
- General testing to ensure compatibility with latest WordPress version (6.3).
- Updating the version number and stable tag