### PR TITLE
Fix workflow action deprecations

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Get all workflow ids and set to env variable
         run: echo ::set-env name=WORKFLOW_IDS_TO_CANCEL::$(curl https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows -s | jq -r '.workflows | map(.id|tostring) | join(",")')
 
-      - uses: styfle/cancel-workflow-action@0.13.1
+      - uses: styfle/cancel-workflow-action@0.14.0
         with:
           workflow_id: ${{ env.WORKFLOW_IDS_TO_CANCEL }}
           access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-php-syntax-errors.yml
+++ b/.github/workflows/check-php-syntax-errors.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
     - name: Checking PHP syntax error
-      uses: overtrue/phplint@master
+      uses: overtrue/phplint@v2
       with:
         path: .
         options: --exclude=*.log

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -8,9 +8,9 @@ jobs:
     name: New tag
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: WordPress Plugin Deploy
-      uses: 10up/action-wordpress-plugin-deploy@master
+      uses: 10up/action-wordpress-plugin-deploy@stable
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
Replace @master refs with pinned versions

- actions/checkout@master → actions/checkout@v4
- overtrue/phplint@master → overtrue/phplint@v2  
- 10up/action-wordpress-plugin-deploy@master → 10up/action-wordpress-plugin-deploy@stable
- styfle/cancel-workflow-action@0.13.1 → styfle/cancel-workflow-action@0.14.0

Resolves CI deprecation warnings and ensures workflows use stable, pinned action versions instead of @master refs.