### PR TITLE
Remove unused acorn dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@wordpress/block-library": "^10.4.0",
     "@wordpress/icons": "^15.4.0",
     "@wordpress/scripts": "^34.1.0",
-    "acorn": "^8.18.0",
     "postcss": "^8.5.26",
     "postcss-loader": "^8.2.1"
   }


### PR DESCRIPTION
Remove acorn from devDependencies

Verified that acorn:
- Is not imported anywhere in source code
- Shows (empty) in 'npm list acorn', meaning no other packages depend on it
- Appears to have been added but is no longer needed

This dependency can be safely removed.