### PR TITLE
fix: pin actions/checkout to current v7

### DIFF
--- a/.github/workflows/check-php-syntax-errors.yml
+++ b/.github/workflows/check-php-syntax-errors.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - name: Checking PHP syntax error
       uses: overtrue/phplint@9.7.2
       with:

--- a/.github/workflows/check-php-syntax-errors.yml
+++ b/.github/workflows/check-php-syntax-errors.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Checking PHP syntax error
       uses: overtrue/phplint@9.7.2
       with:

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -8,7 +8,7 @@ jobs:
     name: New tag
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v7
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@master
       env:

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -9,8 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - name: WordPress Plugin Deploy
-      uses: 10up/action-wordpress-plugin-deploy@master
+      uses: 10up/action-wordpress-plugin-deploy@2.3.0
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
PR #430 moved actions/checkout from @master to @v4, but v7 is the actual current release. Also fixes push-deploy.yml which was still on the unstable @master ref.